### PR TITLE
Python indent fix

### DIFF
--- a/mm-notify.py
+++ b/mm-notify.py
@@ -26,9 +26,13 @@
 import argparse
 import json
 try:
-    import urllib2  # python2
+    # python2
+    import urllib2
+    from urllib import urlencode
 except ModuleNotFoundError:
-    import urllib.request as urllib2  # python3
+    # python3
+    from urllib.parse import urlencode
+    import urllib.request as urllib2
 import os
 
 VERSION = "0.0.1"
@@ -48,11 +52,6 @@ def parse():
                         version='% (prog)s {version}'.format(version=VERSION))
     args = parser.parse_args()
     return args
-
-
-def encode_special_characters(text):
-    text = text.replace("%", "%25")
-    return text
 
 
 def make_data(args):
@@ -89,13 +88,13 @@ def make_data(args):
     payload = {
         "username": args.username,
         "icon_url": args.iconurl,
-        "text": encode_special_characters(text)
+        "text": text
     }
 
     if args.channel:
         payload["channel"] = args.channel
 
-    data = "payload=" + json.dumps(payload)
+    data = urlencode({'payload': json.dumps(payload)})
     return data
 
 

--- a/mm-notify.py
+++ b/mm-notify.py
@@ -64,9 +64,9 @@ def make_data(args):
     elif args.notificationtype.lower() == "restart":
         EMOJI = ":arrows_counterclockwise: "
     elif args.notificationtype.lower() == "exec":
-  EMOJI = ":interrobang: "
+        EMOJI = ":interrobang: "
     elif args.notificationtype.lower() == "unmonitor":
-  EMOJI = ":heavy_exclamation_mark: "
+        EMOJI = ":heavy_exclamation_mark: "
     else:
         EMOJI = ""
 

--- a/mm-notify.py
+++ b/mm-notify.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2
 
 # Copyright (c) 2017 Maxim Odinintsev
-# 
+#
 # Based on Nagios notification plugin by NDrive
 # https://github.com/NDrive/nagios-mattermost
 #
@@ -30,6 +30,7 @@ import os
 
 VERSION = "0.0.1"
 
+
 def parse():
     parser = argparse.ArgumentParser(description='Sends alerts to Mattermost')
     parser.add_argument('--url', help='Incoming Webhook URL', required=True)
@@ -38,7 +39,8 @@ def parse():
                         default='m/monit notify')
     parser.add_argument('--iconurl', help='URL of icon to use for username',
                         default='https://mmonit.com/monit/img/logo.png') # noqa
-    parser.add_argument('--notificationtype', help='Notification Type', default='none')
+    parser.add_argument('--notificationtype', help='Notification Type',
+                        default='none')
     parser.add_argument('--version', action='version',
                         version='% (prog)s {version}'.format(version=VERSION))
     args = parser.parse_args()
@@ -51,10 +53,19 @@ def encode_special_characters(text):
 
 
 def make_data(args):
-    template = "**" + os.environ['MONIT_ACTION'] + "**\n**" + os.environ['MONIT_EVENT'] + "**\n\nHost affected: **" + os.environ['MONIT_HOST'] + "**\nService affected: **" + os.environ['MONIT_SERVICE'] + "**\nDetails: " + os.environ['MONIT_DESCRIPTION']
+    template = "**{action}**\n" \
+               "**{event}**\n\n" \
+               "Host affected: **{host}**\n" \
+               "Service affected: **{service}**\n" \
+               "Details: {details}" \
+               .format(action=os.environ['MONIT_ACTION'],
+                       event=os.environ['MONIT_EVENT'],
+                       host=os.environ['MONIT_HOST'],
+                       service=os.environ['MONIT_SERVICE'],
+                       details=os.environ['MONIT_DESCRIPTION'])
 
     # Emojis
-    print args.notificationtype.lower()
+    print(args.notificationtype.lower())
     if args.notificationtype.lower() == "alert":
         EMOJI = ":sos: "
     elif args.notificationtype.lower() == "stop":
@@ -95,4 +106,4 @@ if __name__ == "__main__":
     args = parse()
     data = make_data(args)
     response = request(args.url, data)
-    print response
+    print(response)

--- a/mm-notify.py
+++ b/mm-notify.py
@@ -25,7 +25,10 @@
 
 import argparse
 import json
-import urllib2
+try:
+    import urllib2  # python2
+except ModuleNotFoundError:
+    import urllib.request as urllib2  # python3
 import os
 
 VERSION = "0.0.1"
@@ -38,7 +41,7 @@ def parse():
     parser.add_argument('--username', help='Username to notify as',
                         default='m/monit notify')
     parser.add_argument('--iconurl', help='URL of icon to use for username',
-                        default='https://mmonit.com/monit/img/logo.png') # noqa
+                        default='https://mmonit.com/monit/img/logo.png')  # noqa
     parser.add_argument('--notificationtype', help='Notification Type',
                         default='none')
     parser.add_argument('--version', action='version',
@@ -97,7 +100,8 @@ def make_data(args):
 
 
 def request(url, data):
-    req = urllib2.Request(url, data)
+    binary_data = data.encode('ascii')
+    req = urllib2.Request(url, binary_data)
     response = urllib2.urlopen(req)
     return response.read()
 


### PR DESCRIPTION
Upon trying to use the script, I was greeted with the following error:

```
File "./mm-notify.py", line 67                                                                                                                                                                                                                                                                                                                                                                                                        
    EMOJI = ":interrobang: "
                           ^
IndentationError: unindent does not match any outer indentation level
```

This PR resolves that, as well as cleaning the Python up a bit to be more easily read, and adds compatibility with Python 3.